### PR TITLE
Task 2: Add favourites feature

### DIFF
--- a/src/components/app.js
+++ b/src/components/app.js
@@ -8,9 +8,12 @@ import Home from "./home";
 import LaunchPads from "./launch-pads";
 import LaunchPad from "./launch-pad";
 
+import { FavouritesProvider } from "../context/favourite-context";
+
 export default function App() {
   return (
     <div>
+    <FavouritesProvider>
       <NavBar />
       <Routes>
         <Route path="/" element={<Home />} />
@@ -19,6 +22,7 @@ export default function App() {
         <Route path="/launch-pads" element={<LaunchPads />} />
         <Route path="/launch-pads/:launchPadId" element={<LaunchPad />} />
       </Routes>
+      </FavouritesProvider>
     </div>
   );
 }

--- a/src/components/app.js
+++ b/src/components/app.js
@@ -9,6 +9,7 @@ import LaunchPads from "./launch-pads";
 import LaunchPad from "./launch-pad";
 
 import { FavouritesProvider } from "../context/favourite-context";
+import FavouritesDrawer from './favourites-drawer'
 
 export default function App() {
   return (
@@ -46,6 +47,7 @@ function NavBar() {
       >
         ¡SPACE·R0CKETS!
       </Text>
+      <FavouritesDrawer />
     </Flex>
   );
 }

--- a/src/components/favourite-button.js
+++ b/src/components/favourite-button.js
@@ -3,28 +3,29 @@ import { IconButton } from "@chakra-ui/core";
 import { Star } from "react-feather";
 import { FavouritesContext } from "../context/favourite-context";
 
-export default function FavouriteButton({type, id}) {
+export default function FavouriteButton({type, item, id}) {
 
     const { favouriteLaunches, favouriteLaunchPads, addLaunchToFaves, removeLaunchFromFaves, addLaunchPadToFaves, removeLaunchPadFromFaves } = useContext(FavouritesContext);
 
-    let currentFavourite = favouriteLaunches.includes(id) || favouriteLaunchPads.includes(id);
+    let currentFavourite = favouriteLaunchPads.find((launchPad) => launchPad.site_id === id) 
+    || favouriteLaunches.find((launch) => launch.flight_number === id);
  
     const isFavourite = currentFavourite ? true : false;
      
-    function handleClick(event, type, id) {
+    function handleClick(event, type, item) {
         event.preventDefault()
         if (type === 'launch') {
 			if (currentFavourite) {
-				removeLaunchFromFaves(id)
+				removeLaunchFromFaves(item)
 			} else {
-				addLaunchToFaves(id)
+				addLaunchToFaves(item)
 			}
 		}
         if (type === 'launchPad') {
             if (currentFavourite) {
-                removeLaunchPadFromFaves(id)
+                removeLaunchPadFromFaves(item)
             } else {
-                addLaunchPadToFaves(id)
+                addLaunchPadToFaves(item)
             }
         }
 	}
@@ -32,7 +33,7 @@ export default function FavouriteButton({type, id}) {
     return (
         <>
           <IconButton
-            onClick={(event) => handleClick(event, type, id)}
+            onClick={(event) => handleClick(event, type, item)}
             as={Star}
             variant="solid"
             colorScheme="white"

--- a/src/components/favourite-button.js
+++ b/src/components/favourite-button.js
@@ -36,7 +36,7 @@ export default function FavouriteButton({type, id}) {
             as={Star}
             variant="solid"
             colorScheme="white"
-            size="sm"
+            size="s"
             stroke="#FFD700"
             style={isFavourite ? { fill: "#FFD700" } : { fill: "none" }}
           />

--- a/src/components/favourite-button.js
+++ b/src/components/favourite-button.js
@@ -1,29 +1,44 @@
-import React, { useState } from 'react';
+import React, { useContext } from 'react';
 import { IconButton } from "@chakra-ui/core";
 import { Star } from "react-feather";
-
+import { FavouritesContext } from "../context/favourite-context";
 
 export default function FavouriteButton({type, id}) {
 
-    const [favourite, setFavourite] = useState(false)
+    const { favouriteLaunches, favouriteLaunchPads, addLaunchToFaves, removeLaunchFromFaves, addLaunchPadToFaves, removeLaunchPadFromFaves } = useContext(FavouritesContext);
 
-    function handleClick(event) {
+    let currentFavourite = favouriteLaunches.includes(id) || favouriteLaunchPads.includes(id);
+ 
+    const isFavourite = currentFavourite ? true : false;
+     
+    function handleClick(event, type, id) {
         event.preventDefault()
-		favourite ? setFavourite(false) : setFavourite(true);
+        if (type === 'launch') {
+			if (currentFavourite) {
+				removeLaunchFromFaves(id)
+			} else {
+				addLaunchToFaves(id)
+			}
+		}
+        if (type === 'launchPad') {
+            if (currentFavourite) {
+                removeLaunchPadFromFaves(id)
+            } else {
+                addLaunchPadToFaves(id)
+            }
+        }
 	}
-
-    console.log(type, id)
 
     return (
         <>
           <IconButton
-            onClick={(event) => handleClick(event, type)}
+            onClick={(event) => handleClick(event, type, id)}
             as={Star}
             variant="solid"
             colorScheme="white"
             size="sm"
             stroke="#FFD700"
-            style={favourite ? { fill: "#FFD700" } : { fill: "none" }}
+            style={isFavourite ? { fill: "#FFD700" } : { fill: "none" }}
           />
         </>
     )

--- a/src/components/favourite-button.js
+++ b/src/components/favourite-button.js
@@ -7,8 +7,7 @@ export default function FavouriteButton({type, item, id}) {
 
     const { favouriteLaunches, favouriteLaunchPads, addLaunchToFaves, removeLaunchFromFaves, addLaunchPadToFaves, removeLaunchPadFromFaves } = useContext(FavouritesContext);
 
-    let currentFavourite = favouriteLaunchPads.find((launchPad) => launchPad.site_id === id) 
-    || favouriteLaunches.find((launch) => launch.flight_number === id);
+    let currentFavourite = favouriteLaunches.find((launch) => launch.flight_number === id) || favouriteLaunchPads.find((launchPad) => launchPad.site_id === id);
  
     const isFavourite = currentFavourite ? true : false;
      

--- a/src/components/favourite-button.js
+++ b/src/components/favourite-button.js
@@ -1,0 +1,30 @@
+import React, { useState } from 'react';
+import { IconButton } from "@chakra-ui/core";
+import { Star } from "react-feather";
+
+
+export default function FavouriteButton({type, id}) {
+
+    const [favourite, setFavourite] = useState(false)
+
+    function handleClick(event) {
+        event.preventDefault()
+		favourite ? setFavourite(false) : setFavourite(true);
+	}
+
+    console.log(type, id)
+
+    return (
+        <>
+          <IconButton
+            onClick={(event) => handleClick(event, type)}
+            as={Star}
+            variant="solid"
+            colorScheme="white"
+            size="sm"
+            stroke="#FFD700"
+            style={favourite ? { fill: "#FFD700" } : { fill: "none" }}
+          />
+        </>
+    )
+}

--- a/src/components/favourites-drawer.js
+++ b/src/components/favourites-drawer.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useContext } from 'react';
 import {
     Drawer,
     DrawerBody,
@@ -8,8 +8,14 @@ import {
     DrawerCloseButton,
     useDisclosure,
     Button,
+    SimpleGrid,
+    Text,
 } from "@chakra-ui/core";
 import { Star } from "react-feather";
+
+import { FavouritesContext } from '../context/favourite-context';
+import { LaunchItem } from './launches';
+import { LaunchPadItem } from './launch-pads';
 
 export default function FavouritesDrawer() {
     const { isOpen, onOpen, onClose } = useDisclosure()
@@ -25,17 +31,58 @@ export default function FavouritesDrawer() {
           placement="right"
           onClose={onClose}
           finalFocusRef={btnRef}
+          size="sm"
+          scrollBehavior={'inside'}
         >
           <DrawerOverlay />
           <DrawerContent>
             <DrawerCloseButton />
-            <DrawerHeader>Your Favourites</DrawerHeader>
-  
+            <DrawerHeader>Favourites</DrawerHeader>
             <DrawerBody>
-              <p>Body goes here</p>
+                <ListLaunches />
+			    <ListLaunchPads />
             </DrawerBody>
           </DrawerContent>
         </Drawer>
       </>
     )
 }
+
+function ListLaunches() {
+    const { favouriteLaunches } = useContext(FavouritesContext);
+	console.log('FavouriteLaunches: ', favouriteLaunches );
+	return (
+        <>
+        <Text fontSize="lg" fontWeight="600" py={3}>
+          Launches ({favouriteLaunches.length})
+        </Text>
+        <SimpleGrid spacing="2">
+          {favouriteLaunches.length > 0 ? (
+            favouriteLaunches.map((launch) => (
+              <LaunchItem key={launch.flight_number} launch={launch} />
+            ))
+          ) : null
+          }
+        </SimpleGrid>
+      </>
+    )
+}
+
+function ListLaunchPads() {
+    const { favouriteLaunchPads } = useContext(FavouritesContext);
+    return (
+        <>
+          <Text fontSize="lg" fontWeight="600" py={3}>
+            Launch Pads ({favouriteLaunchPads.length})
+          </Text>
+          <SimpleGrid spacing={2}>
+            {favouriteLaunchPads.length > 0 ? (
+                favouriteLaunchPads.map((launchPad) => (
+                <LaunchPadItem key={launchPad.site_id} launchPad={launchPad} />
+              ))
+            ) : null
+            }
+          </SimpleGrid>
+        </>
+      );
+};

--- a/src/components/favourites-drawer.js
+++ b/src/components/favourites-drawer.js
@@ -1,0 +1,41 @@
+import React from 'react';
+import {
+    Drawer,
+    DrawerBody,
+    DrawerHeader,
+    DrawerOverlay,
+    DrawerContent,
+    DrawerCloseButton,
+    useDisclosure,
+    Button,
+} from "@chakra-ui/core";
+import { Star } from "react-feather";
+
+export default function FavouritesDrawer() {
+    const { isOpen, onOpen, onClose } = useDisclosure()
+    const btnRef = React.useRef()
+  
+    return (
+      <>
+        <Button leftIcon={Star} variantColor="yellow" ref={btnRef} variant="outline" onClick={onOpen}>
+          Favourites
+        </Button>
+        <Drawer
+          isOpen={isOpen}
+          placement="right"
+          onClose={onClose}
+          finalFocusRef={btnRef}
+        >
+          <DrawerOverlay />
+          <DrawerContent>
+            <DrawerCloseButton />
+            <DrawerHeader>Your Favourites</DrawerHeader>
+  
+            <DrawerBody>
+              <p>Body goes here</p>
+            </DrawerBody>
+          </DrawerContent>
+        </Drawer>
+      </>
+    )
+}

--- a/src/components/launch-pad.js
+++ b/src/components/launch-pad.js
@@ -21,6 +21,7 @@ import { useSpaceX } from "../utils/use-space-x";
 import Error from "./error";
 import Breadcrumbs from "./breadcrumbs";
 import { LaunchItem } from "./launches";
+import FavouriteButton from "./favourite-button"
 
 export default function LaunchPad() {
   let { launchPadId } = useParams();
@@ -90,6 +91,12 @@ function Header({ launchPad }) {
         borderRadius="lg"
       >
         {launchPad.site_name_long}
+        <Flex>
+          <FavouriteButton
+            type={"LaunchPad"}
+            id={launchPad.site_id}
+          />
+        </Flex>
       </Heading>
       <Stack isInline spacing="3">
         <Badge variantColor="purple" fontSize={["sm", "md"]}>

--- a/src/components/launch-pad.js
+++ b/src/components/launch-pad.js
@@ -109,6 +109,7 @@ function Header({ launchPad }) {
         <Box>
           <FavouriteButton
             type={"launchPad"}
+            item={launchPad}
             id={launchPad.site_id}
           />
       </Box>

--- a/src/components/launch-pad.js
+++ b/src/components/launch-pad.js
@@ -93,7 +93,7 @@ function Header({ launchPad }) {
         {launchPad.site_name_long}
         <Flex>
           <FavouriteButton
-            type={"LaunchPad"}
+            type={"launchPad"}
             id={launchPad.site_id}
           />
         </Flex>

--- a/src/components/launch-pad.js
+++ b/src/components/launch-pad.js
@@ -91,12 +91,6 @@ function Header({ launchPad }) {
         borderRadius="lg"
       >
         {launchPad.site_name_long}
-        <Flex>
-          <FavouriteButton
-            type={"launchPad"}
-            id={launchPad.site_id}
-          />
-        </Flex>
       </Heading>
       <Stack isInline spacing="3">
         <Badge variantColor="purple" fontSize={["sm", "md"]}>
@@ -112,6 +106,12 @@ function Header({ launchPad }) {
             Retired
           </Badge>
         )}
+        <Box>
+          <FavouriteButton
+            type={"launchPad"}
+            id={launchPad.site_id}
+          />
+      </Box>
       </Stack>
     </Flex>
   );

--- a/src/components/launch-pads.js
+++ b/src/components/launch-pads.js
@@ -76,27 +76,28 @@ function LaunchPadItem({ launchPad }) {
             {launchPad.successful_launches} succeeded
           </Box>
         </Box>
-
-        <Box
-          mt="1"
-          fontWeight="semibold"
-          as="h4"
-          lineHeight="tight"
-          isTruncated
-        >
-          {launchPad.name}
-        </Box>
+        <Flex>
+          <Box
+            mt="1"
+            fontWeight="semibold"
+            as="h4"
+            lineHeight="tight"
+            isTruncated
+          >
+            {launchPad.name}
+          </Box>
+          <Box ml="auto">
+            <FavouriteButton
+              type={"launchPad"}
+              item={launchPad}
+              id={launchPad.site_id}
+            />
+          </Box>
+        </Flex>
         <Text color="gray.500" fontSize="sm">
           {launchPad.vehicles_launched.join(", ")}
         </Text>
       </Box>
-      <Flex>
-          <FavouriteButton
-            type={"launchPad"}
-            item={launchPad}
-            id={launchPad.site_id}
-          />
-      </Flex>
     </Box>
   );
 }

--- a/src/components/launch-pads.js
+++ b/src/components/launch-pads.js
@@ -42,7 +42,7 @@ export default function LaunchPads() {
   );
 }
 
-function LaunchPadItem({ launchPad }) {
+export function LaunchPadItem({ launchPad }) {
   return (
     <Box
       as={Link}

--- a/src/components/launch-pads.js
+++ b/src/components/launch-pads.js
@@ -1,9 +1,10 @@
 import React from "react";
-import { Badge, Box, SimpleGrid, Text } from "@chakra-ui/core";
+import { Badge, Box, Flex, SimpleGrid, Text } from "@chakra-ui/core";
 import { Link } from "react-router-dom";
 
 import Error from "./error";
 import Breadcrumbs from "./breadcrumbs";
+import FavouriteButton from "./favourite-button"
 import LoadMoreButton from "./load-more-button";
 import { useSpaceXPaginated } from "../utils/use-space-x";
 
@@ -89,6 +90,13 @@ function LaunchPadItem({ launchPad }) {
           {launchPad.vehicles_launched.join(", ")}
         </Text>
       </Box>
+      <Flex>
+          <FavouriteButton
+            type={"launchPad"}
+            item={launchPad}
+            id={launchPad.site_id}
+          />
+      </Flex>
     </Box>
   );
 }

--- a/src/components/launch.js
+++ b/src/components/launch.js
@@ -26,6 +26,7 @@ import { useSpaceX } from "../utils/use-space-x";
 import { formatDateTime, formatDateTimeLocal } from "../utils/format-date";
 import Error from "./error";
 import Breadcrumbs from "./breadcrumbs";
+import FavouriteButton from "./favourite-button"
 
 export default function Launch() {
   let { launchId } = useParams();
@@ -95,6 +96,13 @@ function Header({ launch }) {
         borderRadius="lg"
       >
         {launch.mission_name}
+        <Flex>
+          <FavouriteButton
+            type={"launch"}
+            item={launch}
+            id={launch.flight_number}
+          />
+      </Flex>
       </Heading>
       <Stack isInline spacing="3">
         <Badge variantColor="purple" fontSize={["xs", "md"]}>

--- a/src/components/launch.js
+++ b/src/components/launch.js
@@ -96,13 +96,6 @@ function Header({ launch }) {
         borderRadius="lg"
       >
         {launch.mission_name}
-        <Flex>
-          <FavouriteButton
-            type={"launch"}
-            item={launch}
-            id={launch.flight_number}
-          />
-      </Flex>
       </Heading>
       <Stack isInline spacing="3">
         <Badge variantColor="purple" fontSize={["xs", "md"]}>
@@ -117,6 +110,13 @@ function Header({ launch }) {
             Failed
           </Badge>
         )}
+        <Box>        
+            <FavouriteButton
+              type={"launch"}
+              item={launch}
+              id={launch.flight_number}
+            />
+      </Box>
       </Stack>
     </Flex>
   );

--- a/src/components/launches.js
+++ b/src/components/launches.js
@@ -101,16 +101,24 @@ export function LaunchItem({ launch }) {
             {launch.rocket.rocket_name} &bull; {launch.launch_site.site_name}
           </Box>
         </Box>
-
-        <Box
-          mt="1"
-          fontWeight="semibold"
-          as="h4"
-          lineHeight="tight"
-          isTruncated
-        >
-          {launch.mission_name}
-        </Box>
+        <Flex>
+          <Box
+            mt="1"
+            fontWeight="semibold"
+            as="h4"
+            lineHeight="tight"
+            isTruncated
+          >
+            {launch.mission_name}
+          </Box>
+          <Box ml="auto">
+            <FavouriteButton
+              type={"launch"}
+              item={launch}
+              id={launch.flight_number}
+            />
+          </Box>
+        </Flex>
         <Flex>
           <Text fontSize="sm">{formatDate(launch.launch_date_utc)} </Text>
           <Text color="gray.500" ml="2" fontSize="sm">
@@ -118,13 +126,6 @@ export function LaunchItem({ launch }) {
           </Text>
         </Flex>
       </Box>
-      <Flex>
-          <FavouriteButton
-            type={"launch"}
-            item={launch}
-            id={launch.flight_number}
-          />
-      </Flex>
     </Box>
   );
 }

--- a/src/components/launches.js
+++ b/src/components/launches.js
@@ -7,6 +7,7 @@ import { useSpaceXPaginated } from "../utils/use-space-x";
 import { formatDate } from "../utils/format-date";
 import Error from "./error";
 import Breadcrumbs from "./breadcrumbs";
+import FavouriteButton from "./favourite-button"
 import LoadMoreButton from "./load-more-button";
 
 const PAGE_SIZE = 12;
@@ -20,7 +21,7 @@ export default function Launches() {
       sort: "launch_date_utc",
     }
   );
-  console.log(data, error);
+  // console.log(data, error);
   return (
     <div>
       <Breadcrumbs
@@ -117,6 +118,13 @@ export function LaunchItem({ launch }) {
           </Text>
         </Flex>
       </Box>
+      <Flex>
+          <FavouriteButton
+            type={"launch"}
+            item={launch}
+            id={launch.flight_number}
+          />
+      </Flex>
     </Box>
   );
 }

--- a/src/context/favourite-context.js
+++ b/src/context/favourite-context.js
@@ -1,0 +1,94 @@
+import React, { useEffect, createContext, useReducer } from 'react';
+
+const initialState = {
+  favouriteLaunches: localStorage.getItem("favouriteLaunches")
+  ? JSON.parse(localStorage.getItem("favouriteLaunches"))
+  : [],
+  favouriteLaunchPads: localStorage.getItem("favouriteLaunchPads")
+  ? JSON.parse(localStorage.getItem("favouriteLaunchPads"))
+  : [],
+}
+
+const ADD_FAVE_LAUNCH = "ADD_FAVE_LAUNCH";
+const REMOVE_FAVE_LAUNCH = "REMOVE_FAVE_LAUNCH";
+const ADD_FAVE_LAUNCH_PAD = "ADD_FAVE_LAUNCH_PAD";
+const REMOVE_FAVE_LAUNCH_PAD = "REMOVE_FAVE_LAUNCH_PAD";
+
+export const FavouritesContext = createContext(initialState);
+
+const favouritesReducer = (state = { favouriteLaunches: [], favouriteLaunchPads: [] }, action) => {
+  if (action.type === ADD_FAVE_LAUNCH) {
+    return {
+      ...state, 
+      favouriteLaunches: [action.payload, ...state.favouriteLaunches],
+    }
+  }
+  if (action.type === REMOVE_FAVE_LAUNCH) {
+    const filteredLaunches = state.favouriteLaunches.filter(item => {
+      return item !== action.payload;
+    });
+    return {
+      favouriteLaunches: [...filteredLaunches], favouriteLaunchPads: [...state.favouriteLaunchPads]};
+
+  }
+  if (action.type === ADD_FAVE_LAUNCH_PAD) {
+    return {
+      ...state,
+      favouriteLaunchPads: [action.payload, ...state.favouriteLaunchPads],
+    };
+  }
+  if (action.type === REMOVE_FAVE_LAUNCH_PAD) {
+    const filteredLaunchPads = state.favouriteLaunchPads.filter(item => {
+      return item !== action.payload;
+    });
+    return {
+      favouriteLaunches: [...state.favouriteLaunches], favouriteLaunchPads: [...filteredLaunchPads] };
+
+  }
+  return state;
+};
+
+export const FavouritesProvider = ({children}) => {
+  const [state, dispatch] = useReducer(favouritesReducer, initialState)
+
+  useEffect(() => {
+    localStorage.setItem(
+      "favouriteLaunches",
+      JSON.stringify(state.favouriteLaunches)
+    );
+    localStorage.setItem(
+      "favouriteLaunchPads",
+       JSON.stringify(state.favouriteLaunchPads)
+    );
+  }, [state]);
+
+  const addLaunchToFaves = item => {
+    dispatch ({
+        type: ADD_FAVE_LAUNCH,
+        payload: item,
+    });
+  };
+
+  const removeLaunchFromFaves = item => {
+    dispatch ({
+        type: REMOVE_FAVE_LAUNCH,
+        payload: item,
+    });
+  };
+
+  const addLaunchPadToFaves = item => {
+    dispatch ({
+        type: ADD_FAVE_LAUNCH_PAD,
+        payload: item,
+    });
+  };
+
+  const removeLaunchPadFromFaves = item => {
+    dispatch ({
+        type: REMOVE_FAVE_LAUNCH_PAD,
+        payload: item,
+    });
+  };
+
+  return <FavouritesContext.Provider value={{favouriteLaunches: state.favouriteLaunches, favouriteLaunchPads: state.favouriteLaunchPads, addLaunchToFaves, removeLaunchFromFaves, addLaunchPadToFaves, removeLaunchPadFromFaves}}>{children}</FavouritesContext.Provider>
+}

--- a/src/context/favourite-context.js
+++ b/src/context/favourite-context.js
@@ -25,7 +25,7 @@ const favouritesReducer = (state = { favouriteLaunches: [], favouriteLaunchPads:
   }
   if (action.type === REMOVE_FAVE_LAUNCH) {
     const filteredLaunches = state.favouriteLaunches.filter(item => {
-      return item !== action.payload;
+      return item.flight_number !== action.payload;
     });
     return {
       favouriteLaunches: [...filteredLaunches], favouriteLaunchPads: [...state.favouriteLaunchPads]};
@@ -39,7 +39,7 @@ const favouritesReducer = (state = { favouriteLaunches: [], favouriteLaunchPads:
   }
   if (action.type === REMOVE_FAVE_LAUNCH_PAD) {
     const filteredLaunchPads = state.favouriteLaunchPads.filter(item => {
-      return item !== action.payload;
+      return item.site_id !== action.payload;
     });
     return {
       favouriteLaunches: [...state.favouriteLaunches], favouriteLaunchPads: [...filteredLaunchPads] };
@@ -72,7 +72,7 @@ export const FavouritesProvider = ({children}) => {
   const removeLaunchFromFaves = item => {
     dispatch ({
         type: REMOVE_FAVE_LAUNCH,
-        payload: item,
+        payload: item.flight_number,
     });
   };
 
@@ -86,7 +86,7 @@ export const FavouritesProvider = ({children}) => {
   const removeLaunchPadFromFaves = item => {
     dispatch ({
         type: REMOVE_FAVE_LAUNCH_PAD,
-        payload: item,
+        payload: item.site_id,
     });
   };
 


### PR DESCRIPTION
## Brief
Addition of  a "favourites" feature to the space-rockets app.

Functionality as detailed: https://github.com/cloverc/space-rockets/blob/master/CHALLENGE.md#2-build-a-feature

## Decisions
I decided to implement the state management of the favourites feature using the Context API as the favourites state is not confined to a component but needs to be global to the application. As the application feature may be extended in the future it makes sense to manage state globally.

For the same reason I decided to add access to the favourites drawer within the Navigation Bar of the app. This also allows favourite Launches and Launch Pads to be grouped and listed simultaneously.

I decided to use a `Star` icon for marking the favourites as the "Diamond" icon was not available within the React Feather icon  library that was already a dependency of the app.

## Next Steps
Potential next steps could be: 

- to display an alternative, reduced Launch item format in the drawer as duplicating the current item layout lends itself to the favourites overflowing quite quickly and a reduced layout would make for a better user experience
- to add a more permanent storage mechanism via integrating a database (e.g. MongoDB, Firebase) as any data stored on the client via the localStorage API will only persist locally


